### PR TITLE
test: Remove support for Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,11 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [18, 20]
 
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v4
       with:
-        node-version: ${{ env.NODE_VER }}
+        node-version-file: '.nvmrc'
     - run: npm ci
     - run: npm run lint


### PR DESCRIPTION
### Description

Completed upgrade to Node 20 by removing the Node 18 CI check and using `.nvmrc` for version to use.

See [the tracking issue](https://github.com/openedx/cypress-e2e-tests/issues/125) for further information.