### PR TITLE
fix: set a correct openedx.org/release, change owner

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,8 +12,8 @@ metadata:
       icon: "GitHub"
   annotations:
     openedx.org/arch-interest-groups: ""
-    openedx.org/release: "main"
+    openedx.org/release: "master"
 spec:
-  owner: group:openedx-unmaintained
+  owner: group:committers-cypress-e2e-tests
   type: 'service'
   lifecycle: 'production'


### PR DESCRIPTION
The fix is required for a Sumac release process.

```
Traceback (most recent call last):
  File "/home/nixos/src/oex/repo-tools/.devbox/virtenv/python/.venv/bin/tag_release", line 33, in <module>
    sys.exit(load_entry_point('edx-repo-tools', 'console_scripts', 'tag_release')())
  File "/home/nixos/src/oex/repo-tools/.devbox/virtenv/python/.venv/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/home/nixos/src/oex/repo-tools/.devbox/virtenv/python/.venv/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/home/nixos/src/oex/repo-tools/.devbox/virtenv/python/.venv/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/nixos/src/oex/repo-tools/.devbox/virtenv/python/.venv/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/nixos/src/oex/repo-tools/edx_repo_tools/auth.py", line 224, in wrapped
    f(hub=hub, *args, **kwargs)
  File "/home/nixos/src/oex/repo-tools/edx_repo_tools/release/tag_release.py", line 841, in main
    ret = do_the_work(repos, ref, use_tag, reverse, skip_invalid, interactive, quiet, dry)
  File "/home/nixos/src/oex/repo-tools/edx_repo_tools/release/tag_release.py", line 895, in do_the_work
    ref_info = commit_ref_info(repos, skip_invalid=skip_invalid)
  File "/home/nixos/src/oex/repo-tools/edx_repo_tools/release/tag_release.py", line 294, in commit_ref_info
    ref_info[repo] = get_latest_commit_for_ref(repo, ref)
  File "/home/nixos/src/oex/repo-tools/edx_repo_tools/release/tag_release.py", line 354, in get_latest_commit_for_ref
    raise ValueError(f"In repo {repo}, ref {ref!r} doesn't exist.")
ValueError: In repo openedx/cypress-e2e-tests, ref 'main' doesn't exist.
```