### PR TITLE
fix: update redirect domain for stage env

### DIFF
--- a/cypress/integration/authenticationMFE/tests/testLogin.spec.js
+++ b/cypress/integration/authenticationMFE/tests/testLogin.spec.js
@@ -25,6 +25,6 @@ describe('Login page tests', function () {
 
   it('user can successfully login and redirected to dashboard', function () {
     loginPage.loginUser(Cypress.env('ADMIN_USER_EMAIL'), Cypress.env('ADMIN_USER_PASSWORD'))
-    cy.url().should('contain', 'courses.stage.edx.org')
+    cy.location('hostname').should('eq', 'home.stage.edx.org')
   })
 })


### PR DESCRIPTION
After login the edx stage url should contain
home.stage.edx.org instead of courses.stage.edx.org